### PR TITLE
把 lines 移到 store 里

### DIFF
--- a/src/components/editor/Main.vue
+++ b/src/components/editor/Main.vue
@@ -264,14 +264,14 @@
 
 <script type="text/ecmascript-6">
   import store from '../../store'
-  import { changeCanvasStyle, changeLineStyle } from '../../store/actions'
+  import actions from '../../store/actions'
 
   export default {
     store,
     data() {
       return {
         blocks: [],
-        lines: [],
+        lines: store.state.lines,
         blockCategory: [{ height: 100, width: 150 }],
         editingCategory: null,
         editWidth: 0,
@@ -372,9 +372,14 @@
       deleteBlock(event) {
         if (event.which === 8 && this.activeIndex !== null) {
           event.preventDefault()
+          this.deleteLines(this.blocks[this.activeIndex])
           this.blocks.splice(this.activeIndex, 1)
           this.resetActive()
         }
+      },
+
+      deleteLines(block) {
+        actions.filterLines(store, block)
       },
 
       addCategory() {
@@ -405,7 +410,7 @@
       },
 
       confirmCanvas() {
-        changeCanvasStyle(store, {
+        actions.changeCanvasStyle(store, {
           width: this.editCanvasWidth,
           height: this.editCanvasHeight,
           background: this.editCanvasBackground
@@ -421,7 +426,7 @@
       },
 
       confirmLine() {
-        changeLineStyle(store, {
+        actions.changeLineStyle(store, {
           width: this.editLineWidth,
           color: this.editLineColor
         })
@@ -439,15 +444,11 @@
       },
 
       redrawDisturbedLines(block) {
-        let disturbedLines = []
         this.lines.forEach((line) => {
           if (line.start.block === block || line.end.block === block) {
-            line = Object.assign(line, this.setLine(line.start.block, line.end.block))
-            disturbedLines.push(line)
+            actions.resetLine(store, line, this.setLine(line.start.block, line.end.block))
           }
         })
-        // 把由于模块位移或模块尺寸改变而受到影响的 line 传到 canvas 进行重绘
-
       },
 
       locateCanvas() {
@@ -493,8 +494,7 @@
       getLineCoordinates() {
         let [startBlock, endBlock] = [this.blocks[this.startDot], this.blocks[this.endDot]]
         let line = this.setLine(startBlock, endBlock)
-        this.lines.push(line);
-        // 把 line 传给 canvas 画线
+        actions.addLine(store, line)
         this.startDot = null
         this.endDot = null
       }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,5 +1,10 @@
-export const changeCanvasStyle = makeAction('CHANGE_CANVAS_STYLE')
-export const changeLineStyle = makeAction('CHANGE_LINE_STYLE')
+export default {
+  changeCanvasStyle: makeAction('CHANGE_CANVAS_STYLE'),
+  changeLineStyle: makeAction('CHANGE_LINE_STYLE'),
+  addLine: makeAction('ADD_LINE'),
+  resetLine: makeAction('RESET_LINE'),
+  filterLines: makeAction('FILTER_LINES')
+}
 
 function makeAction (type) {
   return ({ dispatch }, ...args) => dispatch(type, ...args)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -21,7 +21,8 @@ const state = {
         size: 50
       }
     }
-  }
+  },
+  lines: []
 }
 
 const mutations = {
@@ -30,6 +31,17 @@ const mutations = {
   },
   CHANGE_LINE_STYLE (state, style) {
     Object.assign(state.canvas.line, style)
+  },
+  ADD_LINE (state, line) {
+    state.lines.push(line)
+  },
+  RESET_LINE (state, line, newLine) {
+    line = Object.assign(line, newLine)
+  },
+  FILTER_LINES (state, block) {
+    state.lines = state.lines.filter((line) => {
+      return line.start.block !== block && line.end.block !== block
+    })
   }
 }
 


### PR DESCRIPTION
@ppq1991 `lines`数组里存储了所有线条的起点、终点坐标，当框框的操作会引起线条的变化（比如删除一个框框后，要删除连接了这个框框的所有线条）时，`lines`数组会相应变化。这样你就可以观察`store`里的这个数组，有变化后对线条作出重绘、删除、新增操作。